### PR TITLE
Don't invalidate a cache based on custom request args

### DIFF
--- a/includes/RequestThrottler.php
+++ b/includes/RequestThrottler.php
@@ -103,6 +103,26 @@ class RequestThrottler {
 
 
 	private function get_cache_key( ThrottledRequest $throttled_request, $parsed_args ): string {
-		return 'Eco-mode-wp-' . $throttled_request->method . '-' . $throttled_request->url . '-' . md5( \serialize( $parsed_args ) );
+		$relevant_args = [
+			'method'              => $parsed_args['method'],
+			'timeout'             => $parsed_args['timeout'],
+			'redirection'         => $parsed_args['redirection'],
+			'httpversion'         => $parsed_args['httpversion'],
+			'user-agent'          => $parsed_args['user-agent'],
+			'reject_unsafe_urls'  => $parsed_args['reject_unsafe_urls'],
+			'blocking'            => $parsed_args['blocking'],
+			'headers'             => $parsed_args['headers'],
+			'cookies'             => $parsed_args['cookies'],
+			'body'                => $parsed_args['body'],
+			'compress'            => $parsed_args['compress'],
+			'decompress'          => $parsed_args['decompress'],
+			'sslverify'           => $parsed_args['sslverify'],
+			'sslcertificates'     => $parsed_args['sslcertificates'],
+			'stream'              => $parsed_args['stream'],
+			'filename'            => $parsed_args['filename'],
+			'limit_response_size' => $parsed_args['limit_response_size'],
+		];
+
+		return 'Eco-mode-wp-' . $throttled_request->method . '-' . $throttled_request->url . '-' . md5( \serialize( $relevant_args ) );
 	}
 }

--- a/plugin.php
+++ b/plugin.php
@@ -46,8 +46,8 @@ function init(): void {
 	add_action( 'admin_init', [ DisableDashboardWidgets::class, 'init' ] );
 
 	$throttler = new RequestThrottler( [
-		new ThrottledRequest( 'https://planet.wordpress.org/feed/', 'GET' , \WEEK_IN_SECONDS ),
-		new ThrottledRequest( 'https://timeapi.io/api/Time/current/zone?timeZone=Europe/Amsterdam', 'GET', \MINUTE_IN_SECONDS ),
+		new ThrottledRequest( 'https://planet.wordpress.org/feed/', \WEEK_IN_SECONDS , 'GET' ),
+		new ThrottledRequest( 'https://timeapi.io/api/Time/current/zone?timeZone=Europe/Amsterdam', \MINUTE_IN_SECONDS, 'GET' ),
 	] );
 	add_filter( 'pre_http_request', [ $throttler, 'throttle_request' ], 10, 3 );
 	add_filter( 'http_response', [ $throttler, 'cache_response' ], 10, 3 );


### PR DESCRIPTION
Plugins may add args to the request calls that may break caching. For instance, query monitor adds a unique id to each request. This PR ignores those values and only considers the WP core args when determining when a request is the same type