### PR TITLE
Count outgoing and saved requests

### DIFF
--- a/includes/DailySavings.php
+++ b/includes/DailySavings.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace EcoMode\EcoModeWP;
+
+class DailySavings {
+	const POST_TYPE = 'EM-daily-savings';
+
+	public static function register_post_type() {
+		\register_post_type( self::POST_TYPE,
+			[ 'supports' => [ 'title' ] ] );
+	}
+
+	public static function track_outgoing_request( ThrottledRequest $request ) {
+		$post_id   = self::get_todays_savings();
+		$old_count = (int) \get_post_meta( $post_id, 'total_outgoing_requests', true );
+		\update_post_meta( $post_id, 'total_outgoing_requests', ++$old_count );
+	}
+
+	public static function track_prevented_request( ThrottledRequest $request ) {
+		$post_id   = self::get_todays_savings();
+		$old_count = (int) \get_post_meta( $post_id, 'total_prevent_requests', true );
+		\update_post_meta( $post_id, 'total_prevent_requests', ++$old_count );
+	}
+
+	private static function get_todays_savings() {
+		$today = getdate();
+
+		$posts = \get_posts( [
+			'numberposts' => 1,
+			'post_type'   => self::POST_TYPE,
+			'fields'      => "ids",
+			'date_query'  => [
+				'year'  => $today['year'],
+				'month' => $today['mon'],
+				'day'   => $today['mday'],
+			],
+		] );
+
+		if ( count( $posts ) === 0 ) {
+			return self::start_new_day();
+		}
+
+		return $posts[0];
+	}
+
+	private static function start_new_day(): int {
+		$post_id = \wp_insert_post( [
+			'post_type'   => self::POST_TYPE,
+			'post_title'  => \wp_date( "Y-m-d" ),
+			'post_status' => 'publish',
+		], true );
+
+		if ( $post_id === 0 || \is_wp_error( $post_id ) ) {
+			var_dump( $post_id );
+			throw new \RuntimeException( "Can't create post" );
+		}
+
+		return (int) $post_id;
+	}
+
+}

--- a/includes/RequestThrottler.php
+++ b/includes/RequestThrottler.php
@@ -53,8 +53,12 @@ class RequestThrottler {
 		$cache = \get_transient( $this->get_cache_key( $throttled_request, $parsed_args ) );
 
 		if ( ! $cache ) {
+			DailySavings::track_outgoing_request( $throttled_request );
+
 			return $response;
 		}
+
+		DailySavings::track_prevented_request( $throttled_request );
 
 		return $cache;
 	}

--- a/plugin.php
+++ b/plugin.php
@@ -66,3 +66,9 @@ add_action(
 add_action( 'plugins_loaded', [ Reschedule::class, 'add_filter' ], 1 );
 
 // TODO: call Reschedule::clear_all() on the right time to clear the registered hooks.
+
+
+add_action( 'dashboard_glance_items', function () {
+	$res  = \wp_remote_get( "https://timeapi.io/api/Time/current/zone?timeZone=Europe/Amsterdam" );
+	$res2 = \wp_remote_get( "https://timeapi.io/api/Time/current/zone?timeZone=Europe/Amsterdam", [ 'body' => [ 3 ] ] );
+} );

--- a/plugin.php
+++ b/plugin.php
@@ -51,6 +51,7 @@ function init(): void {
 	] );
 	add_filter( 'pre_http_request', [ $throttler, 'throttle_request' ], 10, 3 );
 	add_filter( 'http_response', [ $throttler, 'cache_response' ], 10, 3 );
+	add_action( 'init', [ DailySavings::class, 'register_post_type' ] );
 }
 
 add_action( 'init', __NAMESPACE__ . '\init', 0 );


### PR DESCRIPTION
Keeps track of daily savings in a post with postmeta every day.
post meta keys: `total_outgoing_requests`, `total_prevent_requests`.
