### PR TITLE
Add HTTPS throttle

### DIFF
--- a/includes/HttpsThrottler.php
+++ b/includes/HttpsThrottler.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace EcoMode\EcoModeWP;
+
+use WP_Error;
+
+/**
+ * Https alteration class.
+ */
+class HttpsThrottler {
+	const NAME             = 'https_mods';
+	const SCHEDULED_ACTION = 'wp_https_detection';
+
+	/**
+	 * Throttles https check.
+	 *
+	 */
+	public static function init(): void {		
+		Alter_Schedule::register_alteration(
+			self::NAME,
+			true,
+			self::SCHEDULED_ACTION,
+			wp_is_using_https() ? 'weekly' : 'daily', // Alter to weekly if site is already HTTPS, daily otherwise
+			wp_is_using_https() ? 1.8 : 1,
+			home_url( '/', 'https' )
+		);
+	}
+}

--- a/plugin.php
+++ b/plugin.php
@@ -48,6 +48,7 @@ function init(): void {
     add_action( 'plugins_loaded', [ Dummy::class, 'dummy' ] );
     add_action( 'admin_init', [ Version_Check_Throttles::class, 'init' ] );
     add_action( 'admin_init', [ DisableDashboardWidgets::class, 'init' ] );
+	add_action( 'admin_init', [ HttpsThrottler::class, 'init' ] );
 
 
 	/**


### PR DESCRIPTION
This PR adds HTTPS throttling alteration. It alter from twice daily to weekly if a given site is already using HTTPS (-1.8 HTTP request per day), from twice daily to daily otherwise (-1 http request per day).