### PR TITLE
Add filter to re-enable the news & events dashboard widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,21 @@ add_filter(
 );
 ```
 
+### Disabling unnecessary core features
+
+We take an opinionated approach to disabling core features that most users aren't actually using. One of these is the News &amp; Events Widget on the dashboard, which sends requests each day to pull in new data.
+
+**Public API**
+
+To reactivate the News &amp; Events Widget, you can use the following filter:
+
+```
+add_filter('eco_mode_disable_wordpress_news_events_widget', __return_true);
+```
+
 ### Settings & Chart
 In the plugin's admin setting page, the plugin has:
 * a graph that helps provide information to web owners about the amount of scheduled external requests the website is currently saving
 * a list of external requests whose frequency the web owner can tweak
 
-Those frontend features are currently implemented, but hardcodedly so they don't carry any dynamic functionality yet. 
-
+Those frontend features are currently implemented, but hardcodedly so they don't carry any dynamic functionality yet.

--- a/includes/disable-dashboard-widgets.php
+++ b/includes/disable-dashboard-widgets.php
@@ -7,7 +7,10 @@ namespace EcoMode\EcoModeWP;
 class DisableDashboardWidgets {
 
 	public static function init(): void {
-		// TODO: make this optional through a setting
-		remove_meta_box('dashboard_primary', 'dashboard', 'normal'); // Removes the 'WordPress News' widget
+
+		if (apply_filters('eco_mode_disable_wordpress_news_events_widget', true)) {
+			remove_meta_box('dashboard_primary', 'dashboard', 'normal'); // Removes the 'WordPress News' widget
+		}
+
 	}
 }


### PR DESCRIPTION
See https://github.com/Eco-Mode-WP/Eco-Mode/issues/36.