### PR TITLE
Introduce coverage configuration for PHPUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 .vscode
 phpcs.cache
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
             "\"vendor/bin/phpcs\" --config-set installed_paths vendor/wp-coding-standards/wpcs"
         ],
         "test": [
-            "@php ./vendor/bin/phpunit tests"
+            "@php ./vendor/bin/phpunit"
         ]
     },
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+		 backupGlobals="false"
+		 backupStaticAttributes="false"
+		 colors="true"
+		 convertDeprecationsToExceptions="true"
+		 convertErrorsToExceptions="true"
+		 convertNoticesToExceptions="true"
+		 convertWarningsToExceptions="true"
+		 processIsolation="false"
+		 stopOnError="false"
+		 stopOnFailure="false"
+		 stopOnIncomplete="false"
+		 stopOnSkipped="false"
+		 verbose="true"
+>
+	<coverage includeUncoveredFiles="true">
+		<include>
+			<file>./plugin.php</file>
+			<directory>./includes</directory>
+		</include>
+	</coverage>
+
+	<testsuites>
+		<testsuite name="Eco-Mode">
+			<directory>./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>


### PR DESCRIPTION
- This adds the phpunit result cache to .gitignore, to allow for local caching.
- You can run the tests with `$ XDEBUG_MODE=coverage ./vendor/bin/phpunit  --coverage-text`
- It has the `tests` directory configured as default testsuite, so is no longer needed to pass along

It also updates the `composer test` command to no longer have a configured path. The default path is now configured in the phpunit configuration. This allows running test with a path like `composer test tests/includes/ThrottledRequestTest.php`, to run a subset of tests. 