### PR TITLE
Update Node version in CI pipeline to latest LTS v18

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
         strategy:
             matrix:
-                node: [ 19.1.x ]
+                node: [ 18.15.x ]
                 php: [ 8.0 ]
 
         steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
 			},
 			"devDependencies": {
 				"@dekode/stylelint-config": "1.0.2",
-				"@wordpress/eslint-plugin": "13.0.0",
 				"@wordpress/scripts": "^25.3.0",
 				"classnames": "^2.3.1",
 				"cssnano": "5.1.14",
@@ -1985,17 +1984,17 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.20.1",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.20.1.tgz",
-			"integrity": "sha512-oeJK41dcdqkvdZy/HctKklJNkt/jh+av3PZARrZEl+fs/8HaHeeYoAvEwOV0u5I6bArTF17JEsTZMY359e/nfQ==",
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
 			"dev": true,
 			"dependencies": {
-				"comment-parser": "1.3.0",
+				"comment-parser": "1.3.1",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~2.2.3"
+				"jsdoc-type-pratt-parser": "~3.1.0"
 			},
 			"engines": {
-				"node": "^12 || ^14 || ^16 || ^17"
+				"node": "^14 || ^16 || ^17 || ^18 || ^19"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -3912,25 +3911,6 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
-		"node_modules/@typescript-eslint/experimental-utils": {
-			"version": "5.55.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.55.0.tgz",
-			"integrity": "sha512-3ZqXIZhdGyGQAIIGATeMtg7prA6VlyxGtcy5hYIR/3qUqp3t18pWWUYhL9mpsDm7y8F9mr3ISMt83TiqCt7OPQ==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/utils": "5.55.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "5.55.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.55.0.tgz",
@@ -4343,9 +4323,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.12.0.tgz",
-			"integrity": "sha512-ttydaGiyXop9zJU4kw1hGQiGHgekRg96UR6vfpkTMMD1ceN4k6WipSgPLwYQVynTF1vq31hvjGm2DTwmbL14+A==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.13.0.tgz",
+			"integrity": "sha512-IK8s2xbxLwWSD4COQICbTgbFziKc9Ed8fpWuxtQl3n+2xpyFIfWHvDEt5nGbotj96OEcxQ16h+aTqIcdon/fwQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=14"
@@ -4355,9 +4335,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.13.0.tgz",
-			"integrity": "sha512-Q69CTrytuKzDnA/Awm6D9Fm1s5qSkNDccblHtraujdoAguRmYKKGQidWaNRhXNnAwMIP3sLzPa7C2wRJRxbYLw==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.14.0.tgz",
+			"integrity": "sha512-ZdsM2u/OwqVBQgYrxiX0tJV13GXiQYrNGWnHzpC48tENh7PR3xKcdaLtX6+nnYyyZm3JpQwW9Xog6Dd1AFnJKA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.16.0",
@@ -4366,10 +4346,10 @@
 				"@babel/preset-env": "^7.16.0",
 				"@babel/preset-typescript": "^7.16.0",
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/babel-plugin-import-jsx-pragma": "^4.12.0",
-				"@wordpress/browserslist-config": "^5.12.0",
-				"@wordpress/element": "^5.6.0",
-				"@wordpress/warning": "^2.29.0",
+				"@wordpress/babel-plugin-import-jsx-pragma": "^4.13.0",
+				"@wordpress/browserslist-config": "^5.13.0",
+				"@wordpress/element": "^5.7.0",
+				"@wordpress/warning": "^2.30.0",
 				"browserslist": "^4.17.6",
 				"core-js": "^3.19.1"
 			},
@@ -4384,9 +4364,9 @@
 			"dev": true
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.12.0.tgz",
-			"integrity": "sha512-iNaocEpx81mYI/B3G9KmzljqBjX2fmWEi5X9n2l1FwpAKIyh1gP/k15rexm9oQ3vDp8omc5J/uu9h3a0fB6eHw==",
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.13.0.tgz",
+			"integrity": "sha512-hAvR0GH/76QM4XJDG5z5FZxNM9bruJz0X1I0eindTW0DCQVMjs7XELuhuD428ZIgq9aUWwAozz5OjRUFTxAMaQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=14"
@@ -4409,14 +4389,14 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.6.0.tgz",
-			"integrity": "sha512-pQdpyzUtmn12vvNX26RiYHEPnQHKK24Ro0MK0tGRYcE9BRVgnH54uL03Nfad2zc6TwQUglD/wkRoeonZ0XmVTw==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.7.0.tgz",
+			"integrity": "sha512-sztnsbrmvsiZIxXGvvKx4D/xfhKIKEylDh15Y6PqUpxMqznmnf5/+fxLc9zeVAkV/c+Yd8xp3DxUH230tCAkpQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@types/react": "^18.0.21",
 				"@types/react-dom": "^18.0.6",
-				"@wordpress/escape-html": "^2.29.0",
+				"@wordpress/escape-html": "^2.30.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.2.0",
@@ -4427,9 +4407,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.29.0.tgz",
-			"integrity": "sha512-/zsYF2jXIm7SbLlR0hXHzJpjiSycZ/rPKXWaZRK8EUxzA30FLc7mPiwWY0pmJxi+1mq+q7t8tHhIp01Z64LOBQ==",
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.30.0.tgz",
+			"integrity": "sha512-A0FVcCPSfzCsuoLJOGCKOj3ygg6lWptugtyFcXoELG15AJ3ivfeJEeghZo77YpaWCmyCf0yTC56qbaAa2c48uw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -4438,21 +4418,21 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-13.0.0.tgz",
-			"integrity": "sha512-rOM8wSy+EgsvloB1ypSascLqkEtvqEpanpMvkX35Z/C4wvs81EqqoRGmeWzmtbcmiNkDZ/ZT34PdwE0R3DHPFg==",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-14.3.0.tgz",
+			"integrity": "sha512-rd6vTfvBB7F9n04xUvYvv+F6zSHrMJUaNgwEsiybFWMF2WKssy6fpLgvNHw4bQRWeiCBPbh44tHMr4oAtEwTMg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^5.3.0",
 				"@typescript-eslint/parser": "^5.3.0",
-				"@wordpress/babel-preset-default": "^7.0.0",
-				"@wordpress/prettier-config": "^2.0.0",
+				"@wordpress/babel-preset-default": "^7.14.0",
+				"@wordpress/prettier-config": "^2.13.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^25.2.3",
-				"eslint-plugin-jsdoc": "^37.0.3",
+				"eslint-plugin-jest": "^27.2.1",
+				"eslint-plugin-jsdoc": "^39.6.9",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-prettier": "^3.3.0",
 				"eslint-plugin-react": "^7.27.0",
@@ -4672,9 +4652,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-2.12.0.tgz",
-			"integrity": "sha512-qgQkjpyFtwNA5RP/ZBpceJRZf4rcqjvdVTCoL/sD6Zk+M0Is42t5rFCAoY2NLWaZwgXBTDRaTcgWooZdhdV6bA==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-2.13.0.tgz",
+			"integrity": "sha512-+/CiiWR2QKBkJcshyA6qTpCIo56U8cN9817Yb61dbd5WprDAGf5vFG0i2qsjovER+9r3DHi5iqtjv2qr752NRw==",
 			"dev": true,
 			"engines": {
 				"node": ">=14"
@@ -4770,62 +4750,6 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/@es-joy/jsdoccomment": {
-			"version": "0.36.1",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
-			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
-			"dev": true,
-			"dependencies": {
-				"comment-parser": "1.3.1",
-				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~3.1.0"
-			},
-			"engines": {
-				"node": "^14 || ^16 || ^17 || ^18 || ^19"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin": {
-			"version": "14.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-14.2.0.tgz",
-			"integrity": "sha512-X2I7OkWmJWiT3ZakErD10BPFiIG6VycJUkgrcsfXfD0La4L77qLOKwgfFGEEGHtfo5mjCbrHaG6DcoQPUeotHQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/eslint-parser": "^7.16.0",
-				"@typescript-eslint/eslint-plugin": "^5.3.0",
-				"@typescript-eslint/parser": "^5.3.0",
-				"@wordpress/babel-preset-default": "^7.13.0",
-				"@wordpress/prettier-config": "^2.12.0",
-				"cosmiconfig": "^7.0.0",
-				"eslint-config-prettier": "^8.3.0",
-				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^27.2.1",
-				"eslint-plugin-jsdoc": "^39.6.9",
-				"eslint-plugin-jsx-a11y": "^6.5.1",
-				"eslint-plugin-prettier": "^3.3.0",
-				"eslint-plugin-react": "^7.27.0",
-				"eslint-plugin-react-hooks": "^4.3.0",
-				"globals": "^13.12.0",
-				"requireindex": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=14",
-				"npm": ">=6.14.4"
-			},
-			"peerDependencies": {
-				"@babel/core": ">=7",
-				"eslint": ">=8",
-				"prettier": ">=2",
-				"typescript": ">=4"
-			},
-			"peerDependenciesMeta": {
-				"prettier": {
-					"optional": true
-				},
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@wordpress/scripts/node_modules/@wordpress/stylelint-config": {
 			"version": "21.12.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.12.0.tgz",
@@ -4897,98 +4821,11 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
-		"node_modules/@wordpress/scripts/node_modules/comment-parser": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
 		"node_modules/@wordpress/scripts/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
-		},
-		"node_modules/@wordpress/scripts/node_modules/escape-string-regexp": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/eslint-plugin-jest": {
-			"version": "27.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
-			"integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/utils": "^5.10.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": "^5.0.0",
-				"eslint": "^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@typescript-eslint/eslint-plugin": {
-					"optional": true
-				},
-				"jest": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/eslint-plugin-jsdoc": {
-			"version": "39.9.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.9.1.tgz",
-			"integrity": "sha512-Rq2QY6BZP2meNIs48aZ3GlIlJgBqFCmR55+UBvaDkA3ZNQ0SvQXOs2QKkubakEijV8UbIVbVZKsOVN8G3MuqZw==",
-			"dev": true,
-			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.36.1",
-				"comment-parser": "1.3.1",
-				"debug": "^4.3.4",
-				"escape-string-regexp": "^4.0.0",
-				"esquery": "^1.4.0",
-				"semver": "^7.3.8",
-				"spdx-expression-parse": "^3.0.1"
-			},
-			"engines": {
-				"node": "^14 || ^16 || ^17 || ^18 || ^19"
-			},
-			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/eslint-plugin-prettier": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-			"integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
-			"dev": true,
-			"dependencies": {
-				"prettier-linter-helpers": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			},
-			"peerDependencies": {
-				"eslint": ">=5.0.0",
-				"prettier": ">=1.13.0"
-			},
-			"peerDependenciesMeta": {
-				"eslint-config-prettier": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/global-modules": {
 			"version": "2.0.0",
@@ -5014,21 +4851,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/globals": {
-			"version": "13.20.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/has-flag": {
@@ -5059,15 +4881,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/jsdoc-type-pratt-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
-			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/kind-of": {
@@ -5340,18 +5153,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@wordpress/scripts/node_modules/write-file-atomic": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
@@ -5381,9 +5182,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.29.0.tgz",
-			"integrity": "sha512-e5jhOeX1g9kmr6Z79zjJnbhOdDpZx4alK1rXzV2nKpFs4TIw19rOkSO8i9Y2qmaWtZ2HVs6/uD4KwBPRcZ+eBQ==",
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.30.0.tgz",
+			"integrity": "sha512-G8+eBnetXVWi5ynMoKQOsNIFDuZ13x9iVHcGHaT40U5tLZwW0DUQbbI3cl0VwL//F+0FFJcP5zkjjFNfpItqHA==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -6978,9 +6779,9 @@
 			}
 		},
 		"node_modules/comment-parser": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-			"integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
 			"dev": true,
 			"engines": {
 				"node": ">= 12.0.0"
@@ -8605,19 +8406,19 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "25.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.7.0.tgz",
-			"integrity": "sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==",
+			"version": "27.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
+			"integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/experimental-utils": "^5.0.0"
+				"@typescript-eslint/utils": "^5.10.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": "^4.0.0 || ^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"@typescript-eslint/eslint-plugin": "^5.0.0",
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@typescript-eslint/eslint-plugin": {
@@ -8629,22 +8430,21 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "37.9.7",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.7.tgz",
-			"integrity": "sha512-8alON8yYcStY94o0HycU2zkLKQdcS+qhhOUNQpfONHHwvI99afbmfpYuPqf6PbLz5pLZldG3Te5I0RbAiTN42g==",
+			"version": "39.9.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.9.1.tgz",
+			"integrity": "sha512-Rq2QY6BZP2meNIs48aZ3GlIlJgBqFCmR55+UBvaDkA3ZNQ0SvQXOs2QKkubakEijV8UbIVbVZKsOVN8G3MuqZw==",
 			"dev": true,
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.20.1",
-				"comment-parser": "1.3.0",
-				"debug": "^4.3.3",
+				"@es-joy/jsdoccomment": "~0.36.1",
+				"comment-parser": "1.3.1",
+				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
-				"regextras": "^0.8.0",
-				"semver": "^7.3.5",
+				"semver": "^7.3.8",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"engines": {
-				"node": "^12 || ^14 || ^16 || ^17"
+				"node": "^14 || ^16 || ^17 || ^18 || ^19"
 			},
 			"peerDependencies": {
 				"eslint": "^7.0.0 || ^8.0.0"
@@ -13172,9 +12972,9 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
-			"integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
 			"dev": true,
 			"engines": {
 				"node": ">=12.0.0"
@@ -17226,15 +17026,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/regextras": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
-			"integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.1.14"
 			}
 		},
 		"node_modules/regjsparser": {
@@ -22342,14 +22133,14 @@
 			"dev": true
 		},
 		"@es-joy/jsdoccomment": {
-			"version": "0.20.1",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.20.1.tgz",
-			"integrity": "sha512-oeJK41dcdqkvdZy/HctKklJNkt/jh+av3PZARrZEl+fs/8HaHeeYoAvEwOV0u5I6bArTF17JEsTZMY359e/nfQ==",
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
 			"dev": true,
 			"requires": {
-				"comment-parser": "1.3.0",
+				"comment-parser": "1.3.1",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~2.2.3"
+				"jsdoc-type-pratt-parser": "~3.1.0"
 			}
 		},
 		"@eslint-community/eslint-utils": {
@@ -23825,15 +23616,6 @@
 				}
 			}
 		},
-		"@typescript-eslint/experimental-utils": {
-			"version": "5.55.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.55.0.tgz",
-			"integrity": "sha512-3ZqXIZhdGyGQAIIGATeMtg7prA6VlyxGtcy5hYIR/3qUqp3t18pWWUYhL9mpsDm7y8F9mr3ISMt83TiqCt7OPQ==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/utils": "5.55.0"
-			}
-		},
 		"@typescript-eslint/parser": {
 			"version": "5.55.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.55.0.tgz",
@@ -24145,16 +23927,16 @@
 			"requires": {}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.12.0.tgz",
-			"integrity": "sha512-ttydaGiyXop9zJU4kw1hGQiGHgekRg96UR6vfpkTMMD1ceN4k6WipSgPLwYQVynTF1vq31hvjGm2DTwmbL14+A==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.13.0.tgz",
+			"integrity": "sha512-IK8s2xbxLwWSD4COQICbTgbFziKc9Ed8fpWuxtQl3n+2xpyFIfWHvDEt5nGbotj96OEcxQ16h+aTqIcdon/fwQ==",
 			"dev": true,
 			"requires": {}
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.13.0.tgz",
-			"integrity": "sha512-Q69CTrytuKzDnA/Awm6D9Fm1s5qSkNDccblHtraujdoAguRmYKKGQidWaNRhXNnAwMIP3sLzPa7C2wRJRxbYLw==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.14.0.tgz",
+			"integrity": "sha512-ZdsM2u/OwqVBQgYrxiX0tJV13GXiQYrNGWnHzpC48tENh7PR3xKcdaLtX6+nnYyyZm3JpQwW9Xog6Dd1AFnJKA==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.16.0",
@@ -24163,10 +23945,10 @@
 				"@babel/preset-env": "^7.16.0",
 				"@babel/preset-typescript": "^7.16.0",
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/babel-plugin-import-jsx-pragma": "^4.12.0",
-				"@wordpress/browserslist-config": "^5.12.0",
-				"@wordpress/element": "^5.6.0",
-				"@wordpress/warning": "^2.29.0",
+				"@wordpress/babel-plugin-import-jsx-pragma": "^4.13.0",
+				"@wordpress/browserslist-config": "^5.13.0",
+				"@wordpress/element": "^5.7.0",
+				"@wordpress/warning": "^2.30.0",
 				"browserslist": "^4.17.6",
 				"core-js": "^3.19.1"
 			}
@@ -24178,9 +23960,9 @@
 			"dev": true
 		},
 		"@wordpress/browserslist-config": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.12.0.tgz",
-			"integrity": "sha512-iNaocEpx81mYI/B3G9KmzljqBjX2fmWEi5X9n2l1FwpAKIyh1gP/k15rexm9oQ3vDp8omc5J/uu9h3a0fB6eHw==",
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.13.0.tgz",
+			"integrity": "sha512-hAvR0GH/76QM4XJDG5z5FZxNM9bruJz0X1I0eindTW0DCQVMjs7XELuhuD428ZIgq9aUWwAozz5OjRUFTxAMaQ==",
 			"dev": true
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
@@ -24194,14 +23976,14 @@
 			}
 		},
 		"@wordpress/element": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.6.0.tgz",
-			"integrity": "sha512-pQdpyzUtmn12vvNX26RiYHEPnQHKK24Ro0MK0tGRYcE9BRVgnH54uL03Nfad2zc6TwQUglD/wkRoeonZ0XmVTw==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.7.0.tgz",
+			"integrity": "sha512-sztnsbrmvsiZIxXGvvKx4D/xfhKIKEylDh15Y6PqUpxMqznmnf5/+fxLc9zeVAkV/c+Yd8xp3DxUH230tCAkpQ==",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
 				"@types/react": "^18.0.21",
 				"@types/react-dom": "^18.0.6",
-				"@wordpress/escape-html": "^2.29.0",
+				"@wordpress/escape-html": "^2.30.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.2.0",
@@ -24209,29 +23991,29 @@
 			}
 		},
 		"@wordpress/escape-html": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.29.0.tgz",
-			"integrity": "sha512-/zsYF2jXIm7SbLlR0hXHzJpjiSycZ/rPKXWaZRK8EUxzA30FLc7mPiwWY0pmJxi+1mq+q7t8tHhIp01Z64LOBQ==",
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.30.0.tgz",
+			"integrity": "sha512-A0FVcCPSfzCsuoLJOGCKOj3ygg6lWptugtyFcXoELG15AJ3ivfeJEeghZo77YpaWCmyCf0yTC56qbaAa2c48uw==",
 			"requires": {
 				"@babel/runtime": "^7.16.0"
 			}
 		},
 		"@wordpress/eslint-plugin": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-13.0.0.tgz",
-			"integrity": "sha512-rOM8wSy+EgsvloB1ypSascLqkEtvqEpanpMvkX35Z/C4wvs81EqqoRGmeWzmtbcmiNkDZ/ZT34PdwE0R3DHPFg==",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-14.3.0.tgz",
+			"integrity": "sha512-rd6vTfvBB7F9n04xUvYvv+F6zSHrMJUaNgwEsiybFWMF2WKssy6fpLgvNHw4bQRWeiCBPbh44tHMr4oAtEwTMg==",
 			"dev": true,
 			"requires": {
 				"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^5.3.0",
 				"@typescript-eslint/parser": "^5.3.0",
-				"@wordpress/babel-preset-default": "^7.0.0",
-				"@wordpress/prettier-config": "^2.0.0",
+				"@wordpress/babel-preset-default": "^7.14.0",
+				"@wordpress/prettier-config": "^2.13.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^25.2.3",
-				"eslint-plugin-jsdoc": "^37.0.3",
+				"eslint-plugin-jest": "^27.2.1",
+				"eslint-plugin-jsdoc": "^39.6.9",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-prettier": "^3.3.0",
 				"eslint-plugin-react": "^7.27.0",
@@ -24377,9 +24159,9 @@
 			}
 		},
 		"@wordpress/prettier-config": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-2.12.0.tgz",
-			"integrity": "sha512-qgQkjpyFtwNA5RP/ZBpceJRZf4rcqjvdVTCoL/sD6Zk+M0Is42t5rFCAoY2NLWaZwgXBTDRaTcgWooZdhdV6bA==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-2.13.0.tgz",
+			"integrity": "sha512-+/CiiWR2QKBkJcshyA6qTpCIo56U8cN9817Yb61dbd5WprDAGf5vFG0i2qsjovER+9r3DHi5iqtjv2qr752NRw==",
 			"dev": true,
 			"requires": {}
 		},
@@ -24456,41 +24238,6 @@
 				"webpack-dev-server": "^4.4.0"
 			},
 			"dependencies": {
-				"@es-joy/jsdoccomment": {
-					"version": "0.36.1",
-					"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
-					"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
-					"dev": true,
-					"requires": {
-						"comment-parser": "1.3.1",
-						"esquery": "^1.4.0",
-						"jsdoc-type-pratt-parser": "~3.1.0"
-					}
-				},
-				"@wordpress/eslint-plugin": {
-					"version": "14.2.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-14.2.0.tgz",
-					"integrity": "sha512-X2I7OkWmJWiT3ZakErD10BPFiIG6VycJUkgrcsfXfD0La4L77qLOKwgfFGEEGHtfo5mjCbrHaG6DcoQPUeotHQ==",
-					"dev": true,
-					"requires": {
-						"@babel/eslint-parser": "^7.16.0",
-						"@typescript-eslint/eslint-plugin": "^5.3.0",
-						"@typescript-eslint/parser": "^5.3.0",
-						"@wordpress/babel-preset-default": "^7.13.0",
-						"@wordpress/prettier-config": "^2.12.0",
-						"cosmiconfig": "^7.0.0",
-						"eslint-config-prettier": "^8.3.0",
-						"eslint-plugin-import": "^2.25.2",
-						"eslint-plugin-jest": "^27.2.1",
-						"eslint-plugin-jsdoc": "^39.6.9",
-						"eslint-plugin-jsx-a11y": "^6.5.1",
-						"eslint-plugin-prettier": "^3.3.0",
-						"eslint-plugin-react": "^7.27.0",
-						"eslint-plugin-react-hooks": "^4.3.0",
-						"globals": "^13.12.0",
-						"requireindex": "^1.2.0"
-					}
-				},
 				"@wordpress/stylelint-config": {
 					"version": "21.12.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.12.0.tgz",
@@ -24541,56 +24288,11 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
-				"comment-parser": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-					"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-					"dev": true
-				},
 				"emoji-regex": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-					"dev": true
-				},
-				"eslint-plugin-jest": {
-					"version": "27.2.1",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
-					"integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/utils": "^5.10.0"
-					}
-				},
-				"eslint-plugin-jsdoc": {
-					"version": "39.9.1",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.9.1.tgz",
-					"integrity": "sha512-Rq2QY6BZP2meNIs48aZ3GlIlJgBqFCmR55+UBvaDkA3ZNQ0SvQXOs2QKkubakEijV8UbIVbVZKsOVN8G3MuqZw==",
-					"dev": true,
-					"requires": {
-						"@es-joy/jsdoccomment": "~0.36.1",
-						"comment-parser": "1.3.1",
-						"debug": "^4.3.4",
-						"escape-string-regexp": "^4.0.0",
-						"esquery": "^1.4.0",
-						"semver": "^7.3.8",
-						"spdx-expression-parse": "^3.0.1"
-					}
-				},
-				"eslint-plugin-prettier": {
-					"version": "3.4.1",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-					"integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
-					"dev": true,
-					"requires": {
-						"prettier-linter-helpers": "^1.0.0"
-					}
 				},
 				"global-modules": {
 					"version": "2.0.0",
@@ -24612,15 +24314,6 @@
 						"which": "^1.3.1"
 					}
 				},
-				"globals": {
-					"version": "13.20.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-					"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.20.2"
-					}
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -24640,12 +24333,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"jsdoc-type-pratt-parser": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
-					"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
 					"dev": true
 				},
 				"kind-of": {
@@ -24835,12 +24522,6 @@
 						"has-flag": "^4.0.0"
 					}
 				},
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				},
 				"write-file-atomic": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
@@ -24866,9 +24547,9 @@
 			}
 		},
 		"@wordpress/warning": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.29.0.tgz",
-			"integrity": "sha512-e5jhOeX1g9kmr6Z79zjJnbhOdDpZx4alK1rXzV2nKpFs4TIw19rOkSO8i9Y2qmaWtZ2HVs6/uD4KwBPRcZ+eBQ==",
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.30.0.tgz",
+			"integrity": "sha512-G8+eBnetXVWi5ynMoKQOsNIFDuZ13x9iVHcGHaT40U5tLZwW0DUQbbI3cl0VwL//F+0FFJcP5zkjjFNfpItqHA==",
 			"dev": true
 		},
 		"@xtuc/ieee754": {
@@ -26048,9 +25729,9 @@
 			"dev": true
 		},
 		"comment-parser": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-			"integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
 			"dev": true
 		},
 		"common-path-prefix": {
@@ -27461,27 +27142,26 @@
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "25.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.7.0.tgz",
-			"integrity": "sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==",
+			"version": "27.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
+			"integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "^5.0.0"
+				"@typescript-eslint/utils": "^5.10.0"
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "37.9.7",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.7.tgz",
-			"integrity": "sha512-8alON8yYcStY94o0HycU2zkLKQdcS+qhhOUNQpfONHHwvI99afbmfpYuPqf6PbLz5pLZldG3Te5I0RbAiTN42g==",
+			"version": "39.9.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.9.1.tgz",
+			"integrity": "sha512-Rq2QY6BZP2meNIs48aZ3GlIlJgBqFCmR55+UBvaDkA3ZNQ0SvQXOs2QKkubakEijV8UbIVbVZKsOVN8G3MuqZw==",
 			"dev": true,
 			"requires": {
-				"@es-joy/jsdoccomment": "~0.20.1",
-				"comment-parser": "1.3.0",
-				"debug": "^4.3.3",
+				"@es-joy/jsdoccomment": "~0.36.1",
+				"comment-parser": "1.3.1",
+				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
-				"regextras": "^0.8.0",
-				"semver": "^7.3.5",
+				"semver": "^7.3.8",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"dependencies": {
@@ -30689,9 +30369,9 @@
 			}
 		},
 		"jsdoc-type-pratt-parser": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
-			"integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
 			"dev": true
 		},
 		"jsdom": {
@@ -33634,12 +33314,6 @@
 				"unicode-match-property-ecmascript": "^2.0.0",
 				"unicode-match-property-value-ecmascript": "^2.1.0"
 			}
-		},
-		"regextras": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
-			"integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
-			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
 	},
 	"devDependencies": {
 		"@dekode/stylelint-config": "1.0.2",
-		"@wordpress/eslint-plugin": "13.0.0",
 		"@wordpress/scripts": "^25.3.0",
 		"classnames": "^2.3.1",
 		"cssnano": "5.1.14",


### PR DESCRIPTION
The latest Node LTS version is 18.15.0. Uneven Node versions never get Long Term Support.

`@wordpress/eslint-plugin` was still on v13, which didn't support Node v18. It's actually included in `@wordpress/scripts` on a newer version that does support Node v18. You can verify it still works by running `npm run-script lint` or `npm run-script lint:js` directly.

Also, the CI action `Install dependencies Plugin` now no longer outputs any warnings about outdated software.